### PR TITLE
Add Seek URL to the application config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ docker-compose -f docker/docker-compose.seek.yml -p seek up -d
 docker-compose -f docker/docker-compose.dsw.yml -p dsw up -d
 ```
 
+### Connect Seek
+
+Create a file called `.env` in the root directory of this project. Add the following to the file:
+```
+SEEK_URL=<seek-url>
+```
+Replace `<seek-url>` with the URL of your Seek instance, e.g. `http://localhost:3000` or `https://fairdomhub.org`.
+
 ### Connect DSW
 
 In DSW, add a new document submission service with the following parameters:

--- a/app/api/seek.py
+++ b/app/api/seek.py
@@ -1,4 +1,9 @@
+import os
 import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+SEEK_URL = os.environ.get('SEEK_URL')
 
 
 class SeekClient:
@@ -6,7 +11,7 @@ class SeekClient:
         '''
         Initialize a new Seek client with the given base-64 encoded credentials.
         '''
-        self.base_url = 'http://localhost:3000'
+        self.base_url = SEEK_URL
         self.headers = {
             'Accept': 'application/vnd.api+json',
             'Accept-Charset': 'ISO-8859-1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 waitress
+python-dotenv


### PR DESCRIPTION
Allow the user to point the application to their instance of Seek by adding the URL to the `.env` file.